### PR TITLE
Split file installation and loading commands

### DIFF
--- a/makefile
+++ b/makefile
@@ -24,32 +24,24 @@ debug: bin/$(PROGN)
 	
 clean:
 	@rm -rf bin
-	
-install:
-	@install -m 755 -d \
-		$(DESTDIR)/etc/udev/rules.d \
-		$(DESTDIR)/usr/bin
+
+setup:
+	@install -m 755 -d $(DESTDIR)/etc/udev/rules.d $(DESTDIR)/usr/bin
 	@cp bin/$(PROGN) $(DESTDIR)/usr/bin
 	@test -s $(DESTDIR)/usr/bin/g410-led || ln -s /usr/bin/$(PROGN) $(DESTDIR)/usr/bin/g410-led
 	@test -s $(DESTDIR)/usr/bin/g610-led || ln -s /usr/bin/$(PROGN) $(DESTDIR)/usr/bin/g610-led
 	@test -s $(DESTDIR)/usr/bin/g910-led || ln -s /usr/bin/$(PROGN) $(DESTDIR)/usr/bin/g910-led
-	
 	@cp udev/$(PROGN).rules $(DESTDIR)/etc/udev/rules.d
+	@install -m 755 -d $(DESTDIR)/etc/$(PROGN)/samples $(DESTDIR)$(SYSTEMDDIR)/system
+	@cp sample_profiles/* $(DESTDIR)/etc/$(PROGN)/samples
+	@cp $(DESTDIR)/etc/$(PROGN)/samples/group_keys $(DESTDIR)/etc/$(PROGN)/profile
+	@cp $(DESTDIR)/etc/$(PROGN)/samples/all_off $(DESTDIR)/etc/$(PROGN)/reboot
+	@cp systemd/$(PROGN).service $(DESTDIR)$(SYSTEMDDIR)/system
+	@cp systemd/$(PROGN)-reboot.service $(DESTDIR)$(SYSTEMDDIR)/system
+
+install: setup
 	@udevadm control --reload-rules
-	
 	@test -s /usr/bin/systemd-run && \
-		install -m 755 -d \
-			$(DESTDIR)/etc/$(PROGN)/samples \
-			$(DESTDIR)$(SYSTEMDDIR)/system && \
-		cp sample_profiles/* $(DESTDIR)/etc/$(PROGN)/samples && \
-		test -s $(DESTDIR)/etc/$(PROGN)/profile || \
-			cp $(DESTDIR)/etc/$(PROGN)/samples/group_keys $(DESTDIR)/etc/$(PROGN)/profile
-	@test -s /usr/bin/systemd-run && \
-		test -s $(DESTDIR)/etc/$(PROGN)/reboot || \
-			cp $(DESTDIR)/etc/$(PROGN)/samples/all_off $(DESTDIR)/etc/$(PROGN)/reboot
-	@test -s /usr/bin/systemd-run && \
-		cp systemd/$(PROGN).service $(DESTDIR)$(SYSTEMDDIR)/system && \
-		cp systemd/$(PROGN)-reboot.service $(DESTDIR)$(SYSTEMDDIR)/system && \
 		systemctl daemon-reload && \
 		systemctl start $(PROGN) && \
 		systemctl enable $(PROGN) && \


### PR DESCRIPTION
To ease packaging, the new setup rule only copies files to the correct
location. The install rules perform the commands to load the newly
installed files.

If this PR is accepted, I suggest to publish the following PKGBUILD to the AUR:
```bash
pkgname=g810-led
pkgver=1.0.0
pkgrel=1
pkgdesc="Linux led controller for the Logitech G810, G410, G610 and G910 Keyboard"
arch=('i686' 'x86_64')
url="https://github.com/MatMoul/g810-led/"
license=('GPL3')
depends=('hidapi')
makedepends=('git' 'gcc' 'make')
optdepends=('libusb: alternative USB communication library (slower, more stable)')
backup=("etc/$pkgname/profile" "etc/$pkgname/reboot")
install=$pkgname.install
source=("https://github.com/MatMoul/$pkgname/archive/master.zip")
md5sums=('640905bf863a63dfae3ae952388917e3')

build() {
  cd "$pkgname-master"
  make
  # To build with libusb, run:
  # make LIB=libusb
}

package() {
  cd "$pkgname-master"
  make DESTDIR="$pkgdir/" setup
}
```
along with this install script:
```bash
post_install() {
    udevadm control --reload-rules
    systemctl daemon-reload
    systemctl start g810-led
    systemctl enable g810-led

    echo "Installed unit files:"
    echo "g810-led.service: set keyboard profile on boot"
    echo "g810-led-reboot: set keyboard profile on reboot"
}
```