### PR TITLE
Make hidapi wait for at least 1ms (Fixes #45)

### DIFF
--- a/src/classes/Keyboard.cpp
+++ b/src/classes/Keyboard.cpp
@@ -562,10 +562,9 @@ bool LedKeyboard::sendDataInternal(byte_buffer_t &data) {
 				std::cout<<"Error: Can not write to hidraw, try with the libusb version"<<std::endl;
 				return false;
 			}
-			usleep(500);
 			byte_buffer_t data2;
 			data2.resize(21, 0x00);
-			hid_read_timeout(m_hidHandle, const_cast<unsigned char*>(data2.data()), data2.size(), 0);
+			hid_read_timeout(m_hidHandle, const_cast<unsigned char*>(data2.data()), data2.size(), 1);
 			return true;
 		#elif defined(libusb)
 			if (data.size() > 20) {


### PR DESCRIPTION
 for any answer from the keyboard. Setting this to 0 seems to make hidapi skip the read. And at least the G910 doesn't seem to like this very much.