### PR TITLE
Another fix for G910's firmware crashes

### DIFF
--- a/src/classes/Keyboard.cpp
+++ b/src/classes/Keyboard.cpp
@@ -623,12 +623,10 @@ bool LedKeyboard::sendDataInternal(byte_buffer_t &data) {
 		#if defined(hidapi)
 			data.insert(data.begin(), 0x00);
 			if (hid_write(m_hidHandle, const_cast<unsigned char*>(data.data()), data.size()) < 0) {
-				std::cout<<"Error: Can not write to hidraw, try with the libusb version"<<std::endl;
-				return false;
+				std::cout<<"Error: Can not write to device. Exiting..."<<std::endl;
+				exit(1);
 			}
-			byte_buffer_t data2;
-			data2.resize(21, 0x00);
-			hid_read_timeout(m_hidHandle, const_cast<unsigned char*>(data2.data()), data2.size(), 1);
+			usleep(1100); // Do not remove or decrease this value below 1100 or there will be firmware crashes on G910.
 			return true;
 		#elif defined(libusb)
 			if (data.size() > 20) {


### PR DESCRIPTION
OK. It didn't quite work out with the last fix.

I did some testing with python and your pipe mode and I managed to crash the firmware again.

By investigating this problem I found out that there's actually no data to read back from the keyboard. So all we ever did here is waiting for hid_read_timeout to timeout after 1ms.

Another fact. If it ever stops working it doesn't recover from this problem until g810-led gets restarted. So I went here with a hard exit(1). The nice error message tells us to try libusb and even with libusb it does crash.

I did nothing to fix it with libusb, as you clearly want to get rid of libusb. But I managed to find a workaround for hidlib... a usleep(1100). 1.1ms seems to be enough to keep the firmware alive. Tested with a python script which dims all leds up and down as fast as possible for 24h and no crash occurred.

I'm not happy with it, but it works here now for a week and I couldn't find a way to avoid the magic number 1100.

More infos on how we might reduce this sleep, will follow in a different issue here on Github shortly.