### PR TITLE
Unify version string

### DIFF
--- a/makefile
+++ b/makefile
@@ -16,10 +16,11 @@ includedir?=$(prefix)/include
 
 # Program & versioning information
 PROGN=g810-led
-MAJOR="0"
-MINOR="2"
-MICRO="0"
+MAJOR=0
+MINOR=2
+MICRO=0
 
+CFLAGS+=-DVERSION=\"$(MAJOR).$(MINOR).$(MICRO)\"
 APPSRCS=src/main.cpp src/helpers/*.cpp src/helpers/*.h
 LIBSRCS=src/classes/*.cpp src/classes/*.h
 

--- a/src/helpers/help.cpp
+++ b/src/helpers/help.cpp
@@ -8,13 +8,11 @@ using namespace std;
 
 namespace help {
 	
-	string version = "0.2.0";
-	
 	void usage(char *arg0) {
 		string cmdName = utils::getCmdName(arg0);
 		cout<<cmdName<<endl;
 		cout<<"--------"<<endl;
-		cout<<"Version : "<<version<<endl;
+		cout<<"Version : "<<VERSION<<endl;
 		cout<<endl;
 		cout<<"  -a {color}\t\t\t\tSet all keys color"<<endl;
 		cout<<"  -g {keygroup} {color}\t\t\tSet key group color"<<endl;

--- a/src/helpers/help.h
+++ b/src/helpers/help.h
@@ -12,4 +12,8 @@ namespace help {
 	
 }
 
+#ifndef VERSION
+#define VERSION "unspecified"
+#endif
+
 #endif


### PR DESCRIPTION
Specified version string in makefile will now propogate to VERSION as a
macro appended to CFLAGS.

Cleaned up version string, quotes not necessary when specifying
major/minor/micro, though this is purely cosmetic.

Signed-off-by: Kevin Pearson <pearosn.kevin.m@gmail.com>