### PR TITLE
Support specifying a specific device for executing commands

### DIFF
--- a/src/classes/Keyboard.h
+++ b/src/classes/Keyboard.h
@@ -109,7 +109,15 @@ class LedKeyboard {
 			ctrl_right, shift_right, alt_right, win_right
 			
 		};
-		
+
+		typedef struct {
+			uint16_t vendorID = 0x0;
+			uint16_t productID = 0x0;
+			std::string manufacturer = "";
+			std::string product = "";
+			std::string serialNumber = "";
+			KeyboardModel model;
+		} DeviceInfo;
 		
 		struct Color {
 			uint8_t red;
@@ -127,10 +135,12 @@ class LedKeyboard {
 		~LedKeyboard();
 		
 		
-		bool listKeyboards();
+		std::vector<DeviceInfo> listKeyboards();
 		
 		bool isOpen();
 		bool open();
+		bool open(uint16_t vendorID, uint16_t productID, std::string serial);
+		DeviceInfo getCurrentDevice();
 		bool close();
 		
 		KeyboardModel getKeyboardModel();
@@ -150,7 +160,6 @@ class LedKeyboard {
 		bool setStartupMode(StartupMode startupMode);
 		
 		bool setNativeEffect(NativeEffect effect, NativeEffectPart part, uint8_t speed, Color color);
-		
 		
 		
 	private:
@@ -191,9 +200,7 @@ class LedKeyboard {
 		};
 		
 		bool m_isOpen = false;
-		uint16_t m_vendorID = 0;
-		uint16_t m_productID = 0;
-		KeyboardModel m_keyboardModel = KeyboardModel::unknown;
+		DeviceInfo currentDevice;
 		
 		#if defined(hidapi)
 			hid_device *m_hidHandle;

--- a/src/helpers/help.cpp
+++ b/src/helpers/help.cpp
@@ -16,6 +16,8 @@ namespace help {
 		cout<<"--------"<<endl;
 		cout<<"Version : "<<version<<endl;
 		cout<<endl;
+		cout<<"Usage: "<<cmdName<<" [OPTIONS...] [command] (command arguments)"<<endl;
+		cout<<"Commands:"<<endl;
 		cout<<"  -a {color}\t\t\t\tSet all keys color"<<endl;
 		cout<<"  -g {keygroup} {color}\t\t\tSet key group color"<<endl;
 		cout<<"  -k {key} {color}\t\t\tSet key color"<<endl;
@@ -42,13 +44,18 @@ namespace help {
 		cout<<"  --startup-mode {startup mode}\t\tSet startup mode"<<endl;
 		cout<<endl;
 		cout<<"  --list-keyboards \t\t\tList connected keyboards"<<endl;
+		cout<<"  --print-device\t\t\tPrint device information for the keyboard"<<endl;
 		cout<<endl;
 		cout<<"  --help\t\t\t\tThis help"<<endl;
 		cout<<"  --help-keys\t\t\t\tHelp for keys in groups"<<endl;
 		cout<<"  --help-effects\t\t\tHelp for native effects"<<endl;
 		cout<<"  --help-samples\t\t\tUsage samples"<<endl;
-		cout<<""<<endl;
-		cout<<""<<endl;
+		cout<<endl;
+		cout<<"Options:"<<endl;
+		cout<<"  -dv\t\t\t\t\tDevice vendor ID, such as 046d for Logitech. Can be omitted to match any vendor ID"<<endl;
+		cout<<"  -dp\t\t\t\t\tDevice product ID, such as c337 for Logitech G810. Can be omitted to match any product ID"<<endl;
+		cout<<"  -ds\t\t\t\t\tDevice serial number, Can be omitted to match the first device found"<<endl;
+		cout<<"--------"<<endl;
 		if (cmdName == "g610-led")
 			cout<<"color formats :\t\t\t\tII (hex value for intensity)"<<endl;
 		else
@@ -61,7 +68,7 @@ namespace help {
 		cout<<"key values :\t\t\t\tabc... 123... and other (use --help-keys for more detail)"<<endl;
 		cout<<"group values :\t\t\t\tlogo, indicators, fkeys, ... (use --help-keys for more detail)"<<endl;
 		cout<<"startup mode :\t\t\t\twave, color"<<endl;
-		cout<<""<<endl;
+		cout<<endl;
 	}
 	
 	void keys(char *arg0) {

--- a/src/helpers/utils.cpp
+++ b/src/helpers/utils.cpp
@@ -216,4 +216,12 @@ namespace utils {
 		return true;
 	}
 	
+	bool parseUInt16(std::string val, uint16_t &uint16) {
+		if (val.length() == 1) val = "0" + val;
+		if (val.length() == 2) val = "0" + val;
+		if (val.length() == 3) val = "0" + val;
+		if (val.length() != 4) return false;
+		uint16 = std::stoul("0x" + val, nullptr, 16);
+		return true;
+	}
 }

--- a/src/helpers/utils.h
+++ b/src/helpers/utils.h
@@ -16,6 +16,7 @@ namespace utils {
 	bool parseColor(std::string val, LedKeyboard::Color &color);
 	bool parseSpeed(std::string val, uint8_t &speed);
 	bool parseUInt8(std::string val, uint8_t &uint8);
+	bool parseUInt16(std::string val, uint16_t &uint16);
 	
 }
 

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -280,19 +280,22 @@ int main(int argc, char **argv) {
 			continue;
 		}
 
+		//Commands that do not need to initialize a specific device
+		if (arg == "--help" || arg == "-h") {help::usage(argv[0]); return 0;}
+		else if (arg == "--list-keyboards") return listKeyboards(kbd);
+		else if (arg == "--help-keys") {help::keys(argv[0]); return 0;}
+		else if (arg == "--help-effects") {help::effects(argv[0]); return 0;}
+		else if (arg == "--help-samples") {help::samples(argv[0]); return 0;}
+
+		//Initialize the device for use
 		if (!kbd.open(vendorID, productID, serial)) {
 			std::cout << "Matching or compatible device not found" << std::endl;
 			return 2;
 		}
+
 		// Command arguments, these will cause parsing to ignore anything beyond the command and its arguments
 		if (arg == "-c") return commit(kbd);
-		else if (arg == "--help" || arg == "-h") {help::usage(argv[0]); return 0;}
-		else if (arg == "--help-keys") {help::keys(argv[0]); return 0;}
-		else if (arg == "--help-effects") {help::effects(argv[0]); return 0;}
-		else if (arg == "--help-samples") {help::samples(argv[0]); return 0;}
-		else if (arg == "--list-keyboards") return listKeyboards(kbd);
 		else if (arg == "--print-device") {printDeviceInfo(kbd.getCurrentDevice()); return 0;}
-
 		else if (argc > (argIndex + 1) && arg == "-a") return setAllKeys(kbd, argv[argIndex + 1]);
 		else if (argc > (argIndex + 2) && arg == "-g") return setGroupKeys(kbd, argv[argIndex + 1], argv[argIndex + 2]);
 		else if (argc > (argIndex + 2) && arg == "-k") return setKey(kbd, argv[argIndex + 1], argv[argIndex + 2]);


### PR DESCRIPTION
This adds support in the library and application for specifying a particular device for executing LED commands. It also organizes devices into a maintained structure that can be queried to determine which device would be found, mostly useful when the device is not explicitly specified.

Changes spread across 3 commits:
- library changes in Keyboard.c/Keyboard.h
- A new utility function for parsing uint16_t from a string, to map IDs
- Application changes to include new argument parsing and specifying devices by vendor, device, or serial

More specific changes listed in the commit logs themselves.