### PR TITLE
Fix gpro and uninstall target

### DIFF
--- a/makefile
+++ b/makefile
@@ -97,9 +97,7 @@ uninstall-dev:
 
 uninstall:
 	@test -s /usr/bin/systemd-run && \
-		systemctl disable $(PROGN) && \
 		systemctl disable $(PROGN)-reboot && \
-		rm $(SYSTEMDDIR)/system/$(PROGN).service && \
 		rm $(SYSTEMDDIR)/system/$(PROGN)-reboot.service && \
 		systemctl daemon-reload && \
 		rm -R /etc/$(PROGN)

--- a/udev/g810-led.rules
+++ b/udev/g810-led.rules
@@ -6,4 +6,4 @@ ACTION=="add", SUBSYSTEMS=="usb", ATTRS{idVendor}=="046d", ATTRS{idProduct}=="c3
 ACTION=="add", SUBSYSTEMS=="usb", ATTRS{idVendor}=="046d", ATTRS{idProduct}=="c337", MODE="666" RUN+="/usr/bin/g810-led -p /etc/g810-led/profile"
 ACTION=="add", SUBSYSTEMS=="usb", ATTRS{idVendor}=="046d", ATTRS{idProduct}=="c32b", MODE="666" RUN+="/usr/bin/g910-led -p /etc/g810-led/profile"
 ACTION=="add", SUBSYSTEMS=="usb", ATTRS{idVendor}=="046d", ATTRS{idProduct}=="c335", MODE="666" RUN+="/usr/bin/g910-led -p /etc/g810-led/profile"
-ACTION=="add", SUBSYSTEMS=="usb", ATTRS{idVendor}=="046d", ATTRS{idProduct}=="c339", MODE="666" RUN+="/usr/bin/g810-led -p /etc/gpro-led/profile"
+ACTION=="add", SUBSYSTEMS=="usb", ATTRS{idVendor}=="046d", ATTRS{idProduct}=="c339", MODE="666" RUN+="/usr/bin/gpro-led -p /etc/g810-led/profile"


### PR DESCRIPTION
GPRO udev rule needs to use the /etc/g810-led/profile path like
the others.

Removed uninstallation of g810-led.service that is not being installed
in setup.

Signed-off-by: Lauri Leukkunen <lauri@rahina.org>