### PR TITLE
Update FX Support Notice

### DIFF
--- a/src/helpers/help.cpp
+++ b/src/helpers/help.cpp
@@ -240,7 +240,7 @@ namespace help {
 		cout<<cmdName<<" Effects"<<endl;
 		cout<<"----------------"<<endl;
 		cout<<endl;
-		cout<<"At this time, FX are only tested on g810 !"<<endl;
+		cout<<"At this time, FX are only tested on g810 and g512 !"<<endl;
 		cout<<endl;
 		cout<<"  -fx {effect} {target}"<<endl;
 		cout<<endl;


### PR DESCRIPTION
I've tested the FX support on a g512 and all command work just fine with
the exception of not being able to set a logo color simply because there
is no backlit logo…

This patch just updates the help notice which mentions that the FX
commands are only tested on the g810, suggesting that they might not
work on other keyboards.

Feel free to decline this if you feel that not all keyboard should be mentioned there.