### PR TITLE
Add missing case for G513 when sending keys

### DIFF
--- a/src/classes/Keyboard.cpp
+++ b/src/classes/Keyboard.cpp
@@ -433,6 +433,7 @@ bool LedKeyboard::setKeys(KeyValueArray keyValues) {
 				break;
 			case LedKeyboard::KeyAddressGroup::keys:
 				switch (currentDevice.model) {
+					case LedKeyboard::KeyboardModel::g513:
 					case LedKeyboard::KeyboardModel::g610:
 					case LedKeyboard::KeyboardModel::g810:
 					case LedKeyboard::KeyboardModel::g910:


### PR DESCRIPTION
A test for G513 keyboard model was missing in the setKeys method.