### PR TITLE
Issue 152: The G Pro keyboard lacks dedicated multimedia keys.

### DIFF
--- a/src/classes/Keyboard.cpp
+++ b/src/classes/Keyboard.cpp
@@ -861,9 +861,22 @@ LedKeyboard::byte_buffer_t LedKeyboard::getKeyGroupAddress(LedKeyboard::KeyAddre
 		  return {}; // Device doesn't support per-key setting
 		case KeyboardModel::g410:
     case KeyboardModel::g513:
+		case KeyboardModel::gpro:
+			switch (keyAddressGroup) {
+				case LedKeyboard::KeyAddressGroup::logo:
+					return { 0x11, 0xff, 0x0c, 0x3a, 0x00, 0x10, 0x00, 0x01 };
+				case LedKeyboard::KeyAddressGroup::indicators:
+					return { 0x12, 0xff, 0x0c, 0x3a, 0x00, 0x40, 0x00, 0x05 };
+				case LedKeyboard::KeyAddressGroup::gkeys:
+					return {};
+				case LedKeyboard::KeyAddressGroup::multimedia:
+					return {};
+				case LedKeyboard::KeyAddressGroup::keys:
+					return { 0x12, 0xff, 0x0c, 0x3a, 0x00, 0x01, 0x00, 0x0e };
+			}
+			break;
 		case KeyboardModel::g610:
 		case KeyboardModel::g810:
-		case KeyboardModel::gpro:
 			switch (keyAddressGroup) {
 				case LedKeyboard::KeyAddressGroup::logo:
 					return { 0x11, 0xff, 0x0c, 0x3a, 0x00, 0x10, 0x00, 0x01 };

--- a/src/classes/Keyboard.cpp
+++ b/src/classes/Keyboard.cpp
@@ -860,7 +860,7 @@ LedKeyboard::byte_buffer_t LedKeyboard::getKeyGroupAddress(LedKeyboard::KeyAddre
 		case KeyboardModel::g413:
 		  return {}; // Device doesn't support per-key setting
 		case KeyboardModel::g410:
-    case KeyboardModel::g513:
+		case KeyboardModel::g513:
 		case KeyboardModel::gpro:
 			switch (keyAddressGroup) {
 				case LedKeyboard::KeyAddressGroup::logo:

--- a/src/helpers/help.cpp
+++ b/src/helpers/help.cpp
@@ -16,6 +16,7 @@ namespace help {
 		if(cmdName == "g213-led") return KeyboardFeatures::g213;
 		else if(cmdName == "g410-led") return KeyboardFeatures::g410;
 		else if(cmdName == "g413-led") return KeyboardFeatures::g413;
+		else if(cmdName == "g513-led") return KeyboardFeatures::g513;
 		else if(cmdName == "g610-led") return KeyboardFeatures::g610;
 		else if(cmdName == "g810-led") return KeyboardFeatures::g810;
 		else if(cmdName == "g910-led") return KeyboardFeatures::g910;

--- a/src/helpers/help.h
+++ b/src/helpers/help.h
@@ -29,6 +29,7 @@ namespace help {
 		g213 = rgb | logo1 | numpad | multimedia | setall | setregion | setindicators | poweronfx,
 		g410 = rgb | commit | setall | setgroup | setkey | poweronfx,
 		g413 = intensity | setall,
+		g513 = rgb | commit | numpad | setall | setgroup | setkey | setindicators | poweronfx,
 		g610 = intensity | commit | logo1 | numpad | multimedia | setall | setgroup | setkey | setindicators | poweronfx,
 		g810 = rgb | commit | logo1 | numpad | multimedia | setall | setgroup | setkey | setindicators | poweronfx,
 		g910 = rgb | commit | logo1 | logo2 | numpad | multimedia | gkeys | setall | setgroup | setkey | setindicators | poweronfx,

--- a/src/helpers/help.h
+++ b/src/helpers/help.h
@@ -32,7 +32,7 @@ namespace help {
 		g610 = intensity | commit | logo1 | numpad | multimedia | setall | setgroup | setkey | setindicators | poweronfx,
 		g810 = rgb | commit | logo1 | numpad | multimedia | setall | setgroup | setkey | setindicators | poweronfx,
 		g910 = rgb | commit | logo1 | logo2 | numpad | multimedia | gkeys | setall | setgroup | setkey | setindicators | poweronfx,
-		gpro = rgb | commit | logo1 | multimedia | setall | setgroup | setkey | setindicators | poweronfx	
+		gpro = rgb | commit | logo1 | setall | setgroup | setkey | setindicators | poweronfx
 	};
 	inline KeyboardFeatures operator|(KeyboardFeatures a, KeyboardFeatures b);
 	


### PR DESCRIPTION
Ignore the "multimedia" key group and omit it from the help text.