### PR TITLE
Set effect period in ms or s (Issue #156)

### DIFF
--- a/src/classes/Keyboard.h
+++ b/src/classes/Keyboard.h
@@ -1,6 +1,7 @@
 #ifndef KEYBOARD_CLASS
 #define KEYBOARD_CLASS
 
+#include <chrono>
 #include <iostream>
 #include <vector>
 
@@ -170,8 +171,9 @@ class LedKeyboard {
 		
 		bool setRegion(uint8_t region, Color color);
 		bool setStartupMode(StartupMode startupMode);
-		
-		bool setNativeEffect(NativeEffect effect, NativeEffectPart part, uint8_t speed, Color color);
+
+		bool setNativeEffect(NativeEffect effect, NativeEffectPart part,
+				     std::chrono::duration<uint16_t, std::milli> period, Color color);
 		
 		
 	private:

--- a/src/helpers/help.cpp
+++ b/src/helpers/help.cpp
@@ -89,7 +89,9 @@ namespace help {
 			cout<<"  color formats :\t\t\tII (hex value for intensity)"<<endl;
 		if((features | KeyboardFeatures::setregion) == features)
 			cout<<"  region formats :\t\t\tRN (integer value for region, 1 to 5)"<<endl;
-		cout<<"  speed formats :\t\t\tSS (hex value for speed 01 to ff)"<<endl;
+		cout<<"  period formats :\t\t\tDms (decimal integer; units of milliseconds)"<<endl;
+		cout<<"                  \t\t\tDs  (decimal integer; units of seconds)"<<endl;
+		cout<<"                  \t\t\tSS  (hex value 01 to ff; units of 256ms)"<<endl;
 		cout<<endl;
 		if((features | KeyboardFeatures::setkey) == features)
 			cout<<"  key values :\t\t\t\tabc... 123... and other (use --help-keys for more detail)"<<endl;
@@ -241,17 +243,17 @@ namespace help {
 		cout<<cmdName<<" Effects"<<endl;
 		cout<<"----------------"<<endl;
 		cout<<endl;
-		cout<<"At this time, FX are only tested on g810 and g512 !"<<endl;
+		cout<<"At this time, FX are only tested on g512, g810, and gpro !"<<endl;
 		cout<<endl;
 		cout<<"  -fx {effect} {target}"<<endl;
 		cout<<endl;
 		cout<<"  -fx color {target} {color}"<<endl;
-		cout<<"  -fx breathing {target} {color} {speed}"<<endl;
-		cout<<"  -fx cycle {target} {speed}"<<endl;
-		cout<<"  -fx waves {target} {speed}"<<endl;
-		cout<<"  -fx hwave {target} {speed}"<<endl;
-		cout<<"  -fx vwave {target} {speed}"<<endl;
-		cout<<"  -fx cwave {target} {speed}"<<endl;
+		cout<<"  -fx breathing {target} {color} {period}"<<endl;
+		cout<<"  -fx cycle {target} {period}"<<endl;
+		cout<<"  -fx waves {target} {period}"<<endl;
+		cout<<"  -fx hwave {target} {period}"<<endl;
+		cout<<"  -fx vwave {target} {period}"<<endl;
+		cout<<"  -fx cwave {target} {period}"<<endl;
 		cout<<endl;
 		if((features | KeyboardFeatures::logo1) == features)
 			cout<<"target value :\t\t\t\tall, keys, logo"<<endl;
@@ -261,7 +263,9 @@ namespace help {
 			cout<<"color formats :\t\t\t\tRRGGBB (hex value for red, green and blue)"<<endl;
 		else if((features | KeyboardFeatures::rgb) == features)
 			cout<<"color formats :\t\t\t\tII (hex value for intensity)"<<endl;
-		cout<<"speed formats :\t\t\t\tSS (hex value for speed 01 to ff)"<<endl;
+		cout<<"period formats :\t\t\tDms (decimal integer; units of milliseconds)"<<endl;
+		cout<<"                \t\t\tDs  (decimal integer; units of seconds)"<<endl;
+		cout<<"                \t\t\tSS  (hex value 01 to ff; units of 256ms)"<<endl;
 		cout<<endl;
 	}
 	

--- a/src/helpers/utils.cpp
+++ b/src/helpers/utils.cpp
@@ -203,10 +203,17 @@ namespace utils {
 		return true;
 	}
 	
-	bool parseSpeed(std::string val, uint8_t &speed) {
-		if (val.length() == 1) val = "0" + val;
-		if (val.length() != 2) return false;
-		speed = std::stoul("0x" + val, nullptr, 16);
+	bool parsePeriod(std::string val, std::chrono::duration<uint16_t, std::milli> &period) {
+		if (!val.empty() && val.back() == 's') {
+			if ((val.length() >= 2) && (val[val.length()-2] == 'm'))
+				period = std::chrono::milliseconds(std::stoul(val, nullptr));
+			else
+				period = std::chrono::seconds(std::stoul(val, nullptr));
+		} else {
+			if (val.length() == 1) val = "0" + val;
+			if (val.length() != 2) return false;
+			period = std::chrono::milliseconds(std::stoul("0x" + val, nullptr, 16) << 8);
+		}
 		return true;
 	}
 	

--- a/src/helpers/utils.h
+++ b/src/helpers/utils.h
@@ -1,6 +1,7 @@
 #ifndef UTILS_HELPER
 #define UTILS_HELPER
 
+#include <chrono>
 #include <iostream>
 #include "../classes/Keyboard.h"
 
@@ -14,7 +15,7 @@ namespace utils {
 	bool parseKey(std::string val, LedKeyboard::Key &key);
 	bool parseKeyGroup(std::string val, LedKeyboard::KeyGroup &keyGroup);
 	bool parseColor(std::string val, LedKeyboard::Color &color);
-	bool parseSpeed(std::string val, uint8_t &speed);
+	bool parsePeriod(std::string val, std::chrono::duration<uint16_t, std::milli> &period);
 	bool parseUInt8(std::string val, uint8_t &uint8);
 	bool parseUInt16(std::string val, uint16_t &uint16);
 	

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -106,7 +106,7 @@ int setRegion(LedKeyboard &kbd, std::string arg2, std::string arg3) {
 int setFX(LedKeyboard &kbd, std::string arg2, std::string arg3, std::string arg4, std::string arg5 = "") {
 	LedKeyboard::NativeEffect effect;
 	LedKeyboard::NativeEffectPart effectPart;
-	uint8_t speed = 0;
+	std::chrono::duration<uint16_t, std::milli> period(0);
 	LedKeyboard::Color color;
 	if (! utils::parseNativeEffect(arg2, effect)) return 1;
 	if (! utils::parseNativeEffectPart(arg3, effectPart)) return 1;
@@ -118,20 +118,20 @@ int setFX(LedKeyboard &kbd, std::string arg2, std::string arg3, std::string arg4
 		case LedKeyboard::NativeEffect::breathing:
 			if (! utils::parseColor(arg4, color)) return 1;
 			if (arg5 == "") return 1;
-			if (! utils::parseSpeed(arg5, speed)) return 1;
+			if (! utils::parsePeriod(arg5, period)) return 1;
 			break;
 		case LedKeyboard::NativeEffect::cycle:
 		case LedKeyboard::NativeEffect::waves:
 		case LedKeyboard::NativeEffect::hwave:
 		case LedKeyboard::NativeEffect::vwave:
 		case LedKeyboard::NativeEffect::cwave:
-			if (! utils::parseSpeed(arg4, speed)) return 1;
+			if (! utils::parsePeriod(arg4, period)) return 1;
 			break;
 	}
 
 	if (! kbd.open()) return 1;
 
-	if (! kbd.setNativeEffect(effect, effectPart, speed, color)) return 1;
+	if (! kbd.setNativeEffect(effect, effectPart, period, color)) return 1;
 
 	return 0;
 }


### PR DESCRIPTION
The parsing changes and renaming of `speed` to `period` are pretty straightforward.  I will be happy to change any details that you want me to change.

The reduction of a switch block to a single case in LedKeyboard::setNativeEffect() is the most interesting part of this change.  I did this because my testing showed that most of the parameters of the command did not overlap each other in the different cases; the values of unused fields do not matter.  In my opinion, it is easier to understand what is happening when the code is all in one place.

I'm sure you will want to take some time to test these changes on your own keyboard.  I've tested them thoroughly on the G Pro.  For the timing, I did things like setting a certain period and then counting the number of cycles over the course of a minute.  For example, on my keyboard, a period of `04` yields 58.5 cycles per minute (60*1000/1024); with these changes, a period of `1s` yields 60 cycles per minute.

The run-time performance of std::chrono::duration is the same as a raw integer.