### PR TITLE
G815 Effects Support

### DIFF
--- a/src/classes/Keyboard.cpp
+++ b/src/classes/Keyboard.cpp
@@ -374,9 +374,10 @@ bool LedKeyboard::commit() {
 		case KeyboardModel::g413:
 			return true; // Keyboard is non-transactional
 		case KeyboardModel::g410:
-    case KeyboardModel::g513:
+		case KeyboardModel::g513:
 		case KeyboardModel::g610:
 		case KeyboardModel::g810:
+		case KeyboardModel::g815:
 		case KeyboardModel::gpro:
 			data = { 0x11, 0xff, 0x0c, 0x5a };
 			break;
@@ -541,7 +542,12 @@ bool LedKeyboard::setGroupKeys(KeyGroup keyGroup, LedKeyboard::Color color) {
 			keyArray = keyGroupLogo;
 			break;
 		case KeyGroup::indicators:
-			keyArray = keyGroupIndicators;
+			switch (currentDevice.model) {
+				case KeyboardModel::g815:
+					return true;
+				default:
+					keyArray = keyGroupIndicators;
+			}
 			break;
 		case KeyGroup::gkeys:
 			keyArray = keyGroupGKeys;
@@ -753,12 +759,16 @@ bool LedKeyboard::setNativeEffect(NativeEffect effect, NativeEffectPart part,
 			if (part == NativeEffectPart::logo) return true; //Does not have logo component
 			break;
 		case KeyboardModel::g410:
-    case KeyboardModel::g513:
+		case KeyboardModel::g513:
 		case KeyboardModel::g610: // Unconfirmed
 		case KeyboardModel::g810:
 		case KeyboardModel::gpro:
 			protocolBytes[0] = 0x0d;
 			protocolBytes[1] = 0x3c;
+			break;
+		case KeyboardModel::g815:
+			protocolBytes[0] = 0x0f;
+			protocolBytes[1] = 0x1c;
 			break;
 		case KeyboardModel::g910:
 			protocolBytes[0] = 0x10;
@@ -766,10 +776,6 @@ bool LedKeyboard::setNativeEffect(NativeEffect effect, NativeEffectPart part,
 			break;
 		default:
 			return false;
-	}
-
-	if ((effectGroup == NativeEffectGroup::waves) && (part == NativeEffectPart::logo)) {
-		return setNativeEffect(NativeEffect::color, part, std::chrono::seconds(0), Color({0x00, 0xff, 0xff}), storage);
 	}
 
 	byte_buffer_t data = {
@@ -790,7 +796,54 @@ bool LedKeyboard::setNativeEffect(NativeEffect effect, NativeEffectPart part,
 		0, // unused?
 		0, // unused?
 	};
-	return sendDataInternal(data);
+
+	byte_buffer_t setupData;
+	bool retval;
+	switch (currentDevice.model) {
+		case KeyboardModel::g815:
+			setupData = { 0x11, 0xff, 0x0f, 0x5c, 0x01, 0x03, 0x03 };
+			setupData.resize(20, 0x00);
+			retval = sendDataInternal(setupData);
+
+			data[16] = 0x01;
+
+			switch (part) {
+				case NativeEffectPart::keys:
+					data[4] = 0x01;
+					break;
+				case NativeEffectPart::logo:
+					data[4] = 0x00;
+					switch (effect) {
+						case NativeEffect::breathing:
+							data[5]=0x03;
+							break;
+						case NativeEffect::cwave:
+						case NativeEffect::vwave:
+						case NativeEffect::hwave:
+							data[5]=0x02;
+							data[13]=0x64;
+							break;
+						case NativeEffect::waves:
+						case NativeEffect::cycle:
+							data[5]=0x02;
+							break;
+						default:
+							data[5]=0x01;
+							break;
+					}
+					break;
+				default:
+					break;
+			}
+			break;
+		default: //Many devices may not support logo coloring for wave?
+			if ((effectGroup == NativeEffectGroup::waves) && (part == NativeEffectPart::logo)) {
+				return setNativeEffect(NativeEffect::color, part, std::chrono::seconds(0), Color({0x00, 0xff, 0xff}), storage);
+			}
+			break;
+	}
+	retval = sendDataInternal(data);
+	return retval;
 }
 
 

--- a/src/classes/Keyboard.cpp
+++ b/src/classes/Keyboard.cpp
@@ -739,11 +739,14 @@ bool LedKeyboard::setNativeEffect(NativeEffect effect, NativeEffectPart part,
 				break;
 			case NativeEffectGroup::cycle:
 			case NativeEffectGroup::waves:
+			case NativeEffectGroup::ripple:
 				if (! setGroupKeys(
 					LedKeyboard::KeyGroup::indicators,
 					LedKeyboard::Color({0xff, 0xff, 0xff}))
 				) return false;
 				if (! commit()) return false;
+				break;
+			default:
 				break;
 		}
 		return (
@@ -810,6 +813,19 @@ bool LedKeyboard::setNativeEffect(NativeEffect effect, NativeEffectPart part,
 			switch (part) {
 				case NativeEffectPart::keys:
 					data[4] = 0x01;
+
+					//Seems to conflict with a star-like effect on G410 and G810
+					switch (effect) {
+						case NativeEffect::ripple:
+							//Adjust periodicity
+							data[9]=0x00;
+							data[10]=period.count() >> 8 & 0xff;;
+							data[11]=period.count() & 0xff;
+							data[12]=0x00;
+							break;
+						default:
+							break;
+					}
 					break;
 				case NativeEffectPart::logo:
 					data[4] = 0x00;
@@ -826,6 +842,10 @@ bool LedKeyboard::setNativeEffect(NativeEffect effect, NativeEffectPart part,
 						case NativeEffect::waves:
 						case NativeEffect::cycle:
 							data[5]=0x02;
+							break;
+						case NativeEffect::ripple:
+						case NativeEffect::off:
+							data[5]=0x00;
 							break;
 						default:
 							data[5]=0x01;

--- a/src/classes/Keyboard.h
+++ b/src/classes/Keyboard.h
@@ -53,6 +53,7 @@ class LedKeyboard {
 			{ 0x46d, 0xc338, (uint16_t)KeyboardModel::g610 },
 			{ 0x46d, 0xc331, (uint16_t)KeyboardModel::g810 },
 			{ 0x46d, 0xc337, (uint16_t)KeyboardModel::g810 },
+			{ 0x46d, 0xc33f, (uint16_t)KeyboardModel::g815 },
 			{ 0x46d, 0xc32b, (uint16_t)KeyboardModel::g910 },
 			{ 0x46d, 0xc335, (uint16_t)KeyboardModel::g910 },
 			{ 0x46d, 0xc339, (uint16_t)KeyboardModel::gpro }
@@ -63,9 +64,10 @@ class LedKeyboard {
 			g213,
 			g410,
 			g413,
-      g513,
+			g513,
 			g610,
 			g810,
+			g815,
 			g910,
 			gpro
 		};

--- a/src/classes/Keyboard.h
+++ b/src/classes/Keyboard.h
@@ -79,19 +79,23 @@ class LedKeyboard {
 			color
 		};
 		enum class NativeEffectGroup : uint8_t {
-			color = 0x01,
+			off,
+			color,
 			breathing,
 			cycle,
-			waves
+			waves,
+			ripple
 		};
 		enum class NativeEffect : uint16_t {
+			off,
 			color = static_cast<uint16_t>(NativeEffectGroup::color) << 8,
 			breathing = static_cast<uint16_t>(NativeEffectGroup::breathing) << 8,
 			cycle = static_cast<uint16_t>(NativeEffectGroup::cycle) << 8,
 			waves = static_cast<uint16_t>(NativeEffectGroup::waves) << 8,
 			hwave,
 			vwave,
-			cwave
+			cwave,
+			ripple = static_cast<uint16_t>(NativeEffectGroup::ripple) << 8
 		};
 		enum class NativeEffectPart : uint8_t {
 			all = 0xff,


### PR DESCRIPTION
This contains code for the G815's handling of native effects. Did not yet develop anything for the per-key LED handling.

Notes:
- There is a URB control message to indicate that upcoming messages are effects commands. Only needs to be sent once prior to a sequence of commands, but there is no harm in sending prior to each effect message, so was cleaner in the current codebase to do this.
- Added a new "ripple" effect (0x05), but in testing discovered this to conflict with an undocumented effect on the G410 and G810. Timing for this effect was not thoroughly investigated.
- Ripple effect timing is handled differently than the other effects.
- Added the "off" effect (0x00)
- G815 effects have some cross-effects mapping, so logo effect translations were done. This makes things such as LED value coordination for effects such as the waves synchronize with the keys.


Tested devices:
- G815
- G810
- G410
- G213
- GPRO