### PR TITLE
Stop prepending a zero byte to the input of hid_write()

### DIFF
--- a/src/classes/Keyboard.cpp
+++ b/src/classes/Keyboard.cpp
@@ -798,7 +798,6 @@ bool LedKeyboard::sendDataInternal(byte_buffer_t &data) {
 	if (data.size() > 0) {
 		#if defined(hidapi)
 			if (! open(currentDevice.vendorID, currentDevice.productID, currentDevice.serialNumber)) return false;
-			data.insert(data.begin(), 0x00);
 			if (hid_write(m_hidHandle, const_cast<unsigned char*>(data.data()), data.size()) < 0) {
 				std::cout<<"Error: Can not write to hidraw, try with the libusb version"<<std::endl;
 				return false;


### PR DESCRIPTION
hid_write() expects a report ID in the first byte.  The 0x11 and 0x12
values sent as the first byte of commands are consistent with report
IDs published in the keyboard's USB descriptors.

This change was motivated by commands not working reliably using
hidapi on macOS with a G Pro keyboard.