### PR TITLE
add Logitech G512 SE vid and pid to the list of supported devices

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,6 +7,7 @@ Linux led controller for Logitech G213, G410, G413, G512, G513, G610, G810, G910
 - **G410 Atlas Spectrum**</br>
 - **G413 Carbon**</br>
 - **G512 Carbon**</br>
+- *NEW!* **G512 SE**</br>
 - **G513 Carbon**</br>
 - **G610 Orion Brown**</br>
 - **G610 Orion Red**</br>

--- a/src/classes/Keyboard.h
+++ b/src/classes/Keyboard.h
@@ -45,10 +45,21 @@ class LedKeyboard {
 	public:
 		
 		std::vector<std::vector<uint16_t>> SupportedKeyboards = {
+			// in case they use the same protocol, this is for the
+			//		logitech g600 gaming mouse
+			
+			// { 0x46d, 0xc24a, (uint16_t)KeyboardModel::g610 },
+			
+			
 			{ 0x46d, 0xc336, (uint16_t)KeyboardModel::g213 },
 			{ 0x46d, 0xc330, (uint16_t)KeyboardModel::g410 },
 			{ 0x46d, 0xc33a, (uint16_t)KeyboardModel::g413 },
 			{ 0x46d, 0xc33c, (uint16_t)KeyboardModel::g513 },
+			
+			// this is the one I added for the
+			//		Logitech G512 SE
+			// tested WORKING in Ubuntu 19.10 with hidapi-hidraw
+			{ 0x46d, 0xc342, (uint16_t)KeyboardModel::g513 },
 			{ 0x46d, 0xc333, (uint16_t)KeyboardModel::g610 },
 			{ 0x46d, 0xc338, (uint16_t)KeyboardModel::g610 },
 			{ 0x46d, 0xc331, (uint16_t)KeyboardModel::g810 },


### PR DESCRIPTION
logitech g512-se mechanical keyboard, P/N 820-009154,model Y-U0034
tested working under ubuntu 19.10 with hidapi-hidraw