### PR TITLE
Add new key for ABNT keyboards: abnt_slash

### DIFF
--- a/src/classes/Keyboard.h
+++ b/src/classes/Keyboard.h
@@ -152,6 +152,8 @@ class LedKeyboard {
 			num_minus, num_plus, num_enter,
 			num_1, num_2, num_3, num_4, num_5, num_6, num_7, num_8, num_9, num_0,
 			num_dot, intl_backslash, menu,
+
+			abnt_slash = static_cast<uint8_t>(KeyAddressGroup::keys) << 8 | 0x87,
 			
 			ctrl_left = static_cast<uint8_t>(KeyAddressGroup::keys) << 8 | 0xe0,
 			shift_left, alt_left, win_left,
@@ -248,7 +250,7 @@ class LedKeyboard {
 			Key::n1, Key::n2, Key::n3, Key::n4, Key::n5, Key::n6, Key::n7, Key::n8, Key::n9, Key::n0,
 			Key::enter, Key::backspace, Key::tab, Key::space, Key::minus, Key::equal,
 			Key::open_bracket, Key::close_bracket, Key::backslash, Key::dollar, Key::semicolon, Key::quote, Key::tilde,
-			Key::comma, Key::period, Key::slash, Key::caps_lock, Key::intl_backslash
+			Key::comma, Key::period, Key::slash, Key::caps_lock, Key::intl_backslash, Key::abnt_slash
 		};
 		
 		bool m_isOpen = false;

--- a/src/helpers/help.cpp
+++ b/src/helpers/help.cpp
@@ -262,6 +262,7 @@ namespace help {
 			cout<<"    comma"<<endl;
 			cout<<"    period"<<endl;
 			cout<<"    slash"<<endl;
+			cout<<"    abnt_slash"<<endl;
 		}
 	}
 	

--- a/src/helpers/utils.cpp
+++ b/src/helpers/utils.cpp
@@ -178,6 +178,7 @@ namespace utils {
 		else if (val == "num." || val == "num_period" || val == "numperiod") key = LedKeyboard::Key::num_dot;
 		else if (val == "intl_backslash" || val == "<") key = LedKeyboard::Key::intl_backslash;
 		else if (val == "menu") key = LedKeyboard::Key::menu;
+		else if (val == "abnt_slash" || val == "abnt_c1") key = LedKeyboard::Key::abnt_slash;
 		else if (val == "ctrl_left" || val == "ctrlleft" || val == "ctrll") key = LedKeyboard::Key::ctrl_left;
 		else if (val == "shift_left" || val == "shiftleft" || val == "shiftl") key = LedKeyboard::Key::shift_left;
 		else if (val == "alt_left" || val == "altleft" || val == "altl") key = LedKeyboard::Key::alt_left;


### PR DESCRIPTION
This PR will add support for ABNT Keyboards
    
USB Scan Code: 0x87
Windows Direct Input Name: ABNT_C1


Tested on G512 Carbon BR

Device: Logitech - G512 RGB MECHANICAL GAMING KEYBOARD
        Vendor ID: 046d
        Product ID: c33c
