### PR TITLE
fix: compilation error with GCC 13

### DIFF
--- a/src/helpers/help.h
+++ b/src/helpers/help.h
@@ -18,6 +18,7 @@
 #define HELP_HELPER
 
 #include <iostream>
+#include <cstdint>
 
 namespace help {
 	


### PR DESCRIPTION
Had to apply this patch to make it compile with GCC 13 on openSUSE Tumbleweed.

It would be nice if it could be applied here, too.

https://build.opensuse.org/package/show/hardware/g810-led