### PR TITLE
Include cstdint for uint16_t

### DIFF
--- a/src/helpers/help.h
+++ b/src/helpers/help.h
@@ -17,6 +17,7 @@
 #ifndef HELP_HELPER
 #define HELP_HELPER
 
+#include <cstdint>
 #include <iostream>
 
 namespace help {


### PR DESCRIPTION
Starting with GCC 13, cstdint is included by fewer headers and needs to be explicitly included in help.h, so that uint16_t is defined. See https://gcc.gnu.org/gcc-13/porting_to.html for details.