### PR TITLE
fixed build error

### DIFF
--- a/src/helpers/help.h
+++ b/src/helpers/help.h
@@ -18,6 +18,7 @@
 #define HELP_HELPER
 
 #include <iostream>
+#include <cstdint>
 
 namespace help {
 	


### PR DESCRIPTION
`make` was failing due to a compilation error which is detailed in https://github.com/MatMoul/g810-led/issues/303. The inclusion of the stdint.h header to provide a definition for `uint16_t` has fixed this and the project now successfully builds.