### PR TITLE
Add g810-led-numlock-color.service to reflect numlock state

### DIFF
--- a/makefile
+++ b/makefile
@@ -71,7 +71,8 @@ setup:
 	@cp udev/$(PROGN).rules $(DESTDIR)/etc/udev/rules.d
 	@test -s /usr/bin/systemd-run && \
 		install -m 755 -d $(DESTDIR)$(SYSTEMDDIR)/system && \
-		cp systemd/$(PROGN)-reboot.service $(DESTDIR)$(SYSTEMDDIR)/system
+		cp systemd/$(PROGN)-reboot.service $(DESTDIR)$(SYSTEMDDIR)/system && \
+		cp systemd/$(PROGN)-numlock-color.service $(DESTDIR)$(SYSTEMDDIR)/system
 
 install-lib: lib
 	@install -m 755 -d $(libdir)
@@ -103,6 +104,7 @@ uninstall:
 	@test -s /usr/bin/systemd-run && \
 		systemctl disable $(PROGN)-reboot && \
 		rm $(SYSTEMDDIR)/system/$(PROGN)-reboot.service && \
+		rm $(SYSTEMDDIR)/system/$(PROGN)-numlock-color.service && \
 		systemctl daemon-reload && \
 		rm -R /etc/$(PROGN)
 	

--- a/systemd/g810-led-numlock-color.service
+++ b/systemd/g810-led-numlock-color.service
@@ -1,0 +1,25 @@
+[Unit]
+Description=Update RGB for Num-Lock state
+
+[Service]
+Restart=always
+Environment=NUM_ON_COLOR=FF0000
+Environment=NUM_OFF_COLOR=00FFFF
+
+ExecStart=/bin/bash -c '\
+  LAST_STATE=""; \
+  while true; do \
+    STATE=$(cat /sys/class/leds/*::numlock/brightness | head -n1 ) ; \
+    if [ "$STATE" != "$LAST_STATE" ]; then \
+      if [ "$STATE" -eq 1 ]; then \
+        g810-led -k numlock "$NUM_ON_COLOR" ; \
+      else \
+        g810-led -k numlock "$NUM_OFF_COLOR" ; \
+      fi; \
+      LAST_STATE="$STATE"; \
+    fi; \
+    sleep 0.2; \
+  done;'
+
+[Install]
+WantedBy=multi-user.target


### PR DESCRIPTION
At least the G513 does not seem to have a numlock indicator, but I'd like to see the state.

Do you think this is useful in general?
I couldn't find a better way instead of polling :-/

I wouldn't enable the service by default, so if my suggestion is ok, I'd rather add some documentation that you need to enable the systemd service if you want this behavior…