### PR TITLE
Project not compiling - Added a missing include

### DIFF
--- a/src/helpers/help.h
+++ b/src/helpers/help.h
@@ -17,6 +17,7 @@
 #ifndef HELP_HELPER
 #define HELP_HELPER
 
+#include <cstdint>
 #include <iostream>
 
 namespace help {


### PR DESCRIPTION
I couldn't compile the project, because **uint16_t** was not defined. Probably some compilers are smart enough to guess that **cstdint** should be included, but mine wasn't. I've added a missing include.